### PR TITLE
Add proper label for textarea accessibility

### DIFF
--- a/subscriptions.php
+++ b/subscriptions.php
@@ -561,7 +561,6 @@ $headerClass = count($subscriptions) > 0 ? "main-actions" : "main-actions hidden
     </div>
 
     <div class="form-group">
-      <label for="notes"><?= translate('notes', $i18n) ?></label>
       <label for="notes" class="sr-only"><?= translate('notes', $i18n) ?></label>
       <textarea id="notes" name="notes" placeholder="<?= translate('notes', $i18n) ?>" rows="3"></textarea>
     </div>

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -561,6 +561,7 @@ $headerClass = count($subscriptions) > 0 ? "main-actions" : "main-actions hidden
     </div>
 
     <div class="form-group">
+      <label for="notes"><?= translate('notes', $i18n) ?></label>
       <textarea id="notes" name="notes" placeholder="<?= translate('notes', $i18n) ?>" rows="3"></textarea>
     </div>
 

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -562,6 +562,7 @@ $headerClass = count($subscriptions) > 0 ? "main-actions" : "main-actions hidden
 
     <div class="form-group">
       <label for="notes"><?= translate('notes', $i18n) ?></label>
+      <label for="notes" class="sr-only"><?= translate('notes', $i18n) ?></label>
       <textarea id="notes" name="notes" placeholder="<?= translate('notes', $i18n) ?>" rows="3"></textarea>
     </div>
 


### PR DESCRIPTION
Add a label element to the notes textarea for improved accessibility, ensuring screen readers consistently announce the field.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8449e2e-eae8-4248-91c5-b3baadb4692b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f8449e2e-eae8-4248-91c5-b3baadb4692b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

