### PR TITLE
feat: Multi-line notes field with proper formatting and XSS protection

### DIFF
--- a/endpoints/subscription/get.php
+++ b/endpoints/subscription/get.php
@@ -23,7 +23,7 @@ if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === true) {
             $subscriptionData['next_payment'] = $row['next_payment'];
             $subscriptionData['frequency'] = $row['frequency'];
             $subscriptionData['cycle'] = $row['cycle'];
-            $subscriptionData['notes'] = htmlspecialchars_decode($row['notes'] ?? "");
+            $subscriptionData['notes'] = $row['notes'] ?? "";
             $subscriptionData['payment_method_id'] = $row['payment_method_id'];
             $subscriptionData['payer_user_id'] = $row['payer_user_id'];
             $subscriptionData['category_id'] = $row['category_id'];

--- a/includes/list_subscriptions.php
+++ b/includes/list_subscriptions.php
@@ -338,7 +338,7 @@ function printSubscriptions($subscriptions, $sort, $categories, $members, $i18n,
                     <div class="subscription-notes">
                         <span class="notes">
                             <?php include $imagePath . "images/siteicons/svg/notes.php"; ?>
-                            <?= $subscription['notes'] ?>
+                            <?= nl2br(htmlspecialchars($subscription['notes'])) ?>
                         </span>
                     </div>
                     <?php

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1301,6 +1301,7 @@ input[type="email"],
 input[type="password"],
 input[type="date"],
 input[type="number"],
+textarea,
 select {
   width: 100%;
   padding: 0px 15px;
@@ -1329,6 +1330,15 @@ input[type="color"] {
 
 .one-third {
   max-width: 33%;
+}
+
+textarea {
+  resize: vertical;
+  height: 72px;
+  min-height: 72px;
+  max-height: 200px;
+  padding-top: 12px;
+  vertical-align: top;
 }
 
 select {

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -491,7 +491,8 @@ $headerClass = count($subscriptions) > 0 ? "main-actions" : "main-actions hidden
     </div>
 
     <div class="form-group">
-      <input type="text" id="notes" name="notes" placeholder="<?= translate('notes', $i18n) ?>">
+      <label for="notes" class="sr-only"><?= translate('notes', $i18n) ?></label>
+      <textarea id="notes" name="notes" placeholder="<?= translate('notes', $i18n) ?>" rows="3"></textarea>
     </div>
 
     <div class="form-group">


### PR DESCRIPTION
## Problem
The current notes field is a single-line input, making it difficult for users to enter longer, formatted notes about their subscriptions. Additionally, there's a potential XSS vulnerability where notes aren't properly escaped on display.

## Solution
- **Convert to textarea**: Replace single-line input with multi-line textarea for better user experience
- **Accessibility**: Add screen-reader-only label for better accessibility 
- **Line break preservation**: Use `nl2br()` to preserve line breaks when displaying notes
- **XSS protection**: Add proper `htmlspecialchars()` escaping to prevent XSS attacks
- **Better styling**: Style textarea with vertical resize and appropriate height
- **Fix double-escaping**: Remove `htmlspecialchars_decode()` in endpoint to prevent display issues

## Changes Made
- `subscriptions.php`: Convert input to textarea with accessibility label
- `styles/styles.css`: Add textarea styling with vertical resize
- `includes/list_subscriptions.php`: Add XSS protection and line break preservation
- `endpoints/subscription/get.php`: Remove double-escaping to fix display

## Screenshots
**Before**: Single-line input field
**After**: Multi-line textarea that preserves formatting

## Testing
- Create/edit subscription with multi-line notes
- Verify line breaks are preserved on display
- Test with HTML/special characters to confirm XSS protection
- Check accessibility with screen readers

## Risk Assessment
- **Low risk**: Simple UI enhancement with backward compatibility
- **Security improvement**: Adds XSS protection where it was missing
- **No breaking changes**: Existing single-line notes will work fine

This addresses a common user request for better notes functionality while improving security.

---

**Next Step**: This PR can be used as a template to create a PR against the upstream `ellite/Wallos` repository.